### PR TITLE
Update `Numcodecs` to version `0.9.1`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,14 +19,12 @@ build:
     - set DISABLE_NUMCODECS_AVX2=""  # [win]
     - {{ PYTHON }} -m pip install . -vv
   # numcodecs is not currently supported on s390x
-  skip: true  # [s390x]
+  skip: true  # [py<36]
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - python                                 # [build_platform != target_platform]
-    - cython                                 # [build_platform != target_platform]
   host:
     - python
     - pip
@@ -42,7 +40,6 @@ requirements:
 test:
   requires:
     - pytest
-    - python
     - pip
   imports:
     - numcodecs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<36]
   script:
     - export DISABLE_NUMCODECS_AVX2=""  # [unix]
     - set DISABLE_NUMCODECS_AVX2=""  # [win]
@@ -32,14 +33,14 @@ requirements:
     - setuptools_scm >1.5.4
     - wheel
   run:
-    - python >=3.6
+    - python
     - numpy >=1.7
     - msgpack-python
 
 test:
   requires:
     - pytest
-    - python < 3.10
+    - python
     - pip
   imports:
     - numcodecs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
     - set DISABLE_NUMCODECS_AVX2=""  # [win]
     - {{ PYTHON }} -m pip install . -vv
   # numcodecs is not currently supported on s390x
-  skip: true  # [py<36]
+  skip: true  # [py<36 or s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,6 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
   script:
     - export DISABLE_NUMCODECS_AVX2=""  # [unix]
     - set DISABLE_NUMCODECS_AVX2=""  # [win]
@@ -24,6 +23,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - cython                                 # [build_platform != target_platform]
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,15 +15,17 @@ build:
   number: 0
   script:
     - export DISABLE_NUMCODECS_AVX2=""  # [unix]
+    - export DISABLE_NUMCODECS_SSE2=""  # [arm64]
     - set DISABLE_NUMCODECS_AVX2=""  # [win]
     - {{ PYTHON }} -m pip install . -vv
+  # numcodecs is not currently supported on s390x
+  skip: true  # [s390x]
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - cython                                 # [build_platform != target_platform]
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "numcodecs" %}
-{% set version = "0.8.0" %}
-{% set sha256 = "7c7d0ea56b5e2a267ae785bdce47abed62829ef000f03be8e32e30df62d3749c" %}
+{% set version = "0.9.1" %}
+{% set sha256 = "35adbcc746b95e3ac92e949a161811f5aa2602b9eb1ef241b5ea6f09bb220997" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,26 +25,29 @@ requirements:
     - python                                 # [build_platform != target_platform]
     - cython                                 # [build_platform != target_platform]
   host:
-    - python >=3.6,<4
+    - python
     - pip
     - cython
     - setuptools >18.0
     - setuptools_scm >1.5.4
     - wheel
   run:
-    - python >=3.6,<4
+    - python >=3.6
     - numpy >=1.7
     - msgpack-python
 
 test:
   requires:
     - pytest
+    - python < 3.10
+    - pip
   imports:
     - numcodecs
     - numcodecs.blosc
     - numcodecs.lz4
     - numcodecs.zstd
   commands:
+    - pip check
     - pytest -v --pyargs numcodecs
 
 about:


### PR DESCRIPTION
`numcodecs` version `0.9.1`

1. check the upstream
https://github.com/zarr-developers/numcodecs/tree/v0.9.1

2. check the pinnings
https://github.com/zarr-developers/numcodecs/blob/v0.9.1/tox.ini

https://github.com/zarr-developers/numcodecs/blob/v0.9.1/setup.py

https://github.com/zarr-developers/numcodecs/blob/v0.9.1/requirements_test.txt

https://github.com/zarr-developers/numcodecs/blob/v0.9.1/requirements_rtfd.txt

https://github.com/zarr-developers/numcodecs/blob/v0.9.1/requirements_dev.txt

https://github.com/zarr-developers/numcodecs/blob/v0.9.1/requirements.txt

3. check the changelogs
https://github.com/zarr-developers/numcodecs/blob/v0.9.1/docs/release.rst

There were no breaking changes mentioned in the changelog, only bug fixes

4. additional research
https://github.com/conda-forge/numcodecs-feedstock/issues

There were no breaking changes mentioned in conda-forge

5. verify dev_url
https://github.com/zarr-developers/numcodecs

6. verify doc_url
https://numcodecs.readthedocs.io/en/stable/

7. pip in the test section

8. veriy the test section

9. additional tests

In order to test the `numcodecs` package version `0.9.1` the following
command was used:
`conda build numcodecs-feedstock --test`
the test result was the following:
`All tests passed`

Based on the research findings and the test results we can conclude
that it is safe to update `numcodecs` to version `0.9.1`