### PR TITLE
numcodecs 0.10.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,10 +36,11 @@ requirements:
   run:
     - python
     - entrypoints
+    # numcodecs/__init__.py requires msgpack,
+    # see https://github.com/zarr-developers/numcodecs/blob/c15e185f6c2d4fa3dc285ac7c975291ef78d1059/numcodecs/__init__.py#L107
+    - msgpack-python
     - numpy >=1.7
     - typing-extensions >=3.7.4
-  run_constrained:
-    - msgpack-python
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,13 +13,14 @@ source:
 
 build:
   number: 0
+  # numcodecs is not currently supported on s390x
+  skip: True  # [py<37 or s390x]
   script:
     - export DISABLE_NUMCODECS_AVX2=""  # [unix]
     - export DISABLE_NUMCODECS_SSE2=""  # [arm64]
     - set DISABLE_NUMCODECS_AVX2=""  # [win]
+    - export CFLAGS="${CFLAGS} -pthread"  # [aarch64 or ppc64le]
     - {{ PYTHON }} -m pip install . -vv
-  # numcodecs is not currently supported on s390x
-  skip: true  # [py<36 or s390x]
 
 requirements:
   build:
@@ -29,12 +30,15 @@ requirements:
     - python
     - pip
     - cython
-    - setuptools >18.0
-    - setuptools_scm >1.5.4
+    - setuptools
+    - setuptools_scm
     - wheel
   run:
     - python
+    - entrypoints
     - numpy >=1.7
+    - typing-extensions >=3.7.4
+  run_constrained:
     - msgpack-python
 
 test:
@@ -56,6 +60,8 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: A Python package providing buffer compression and transformation codecs for use in data storage and communication applications.
+  description: |
+    
   dev_url: https://github.com/zarr-developers/numcodecs
   doc_url: https://numcodecs.readthedocs.io/en/stable/
   

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,15 @@ about:
   license_file: LICENSE
   summary: A Python package providing buffer compression and transformation codecs for use in data storage and communication applications.
   description: |
-    
+    Numcodecs is a Python package providing buffer compression and transformation codecs for use in data storage and communication applications. These include:
+
+    Compression codecs, e.g., Zlib, BZ2, LZMA, ZFPY and Blosc.
+
+    Pre-compression filters, e.g., Delta, Quantize, FixedScaleOffset, PackBits, Categorize.
+
+    Integrity checks, e.g., CRC32, Adler32.
+
+    All codecs implement the same API, allowing codecs to be organized into pipelines in a variety of ways.
   dev_url: https://github.com/zarr-developers/numcodecs
   doc_url: https://numcodecs.readthedocs.io/en/stable/
   

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ build:
     - export DISABLE_NUMCODECS_AVX2=""  # [unix]
     - export DISABLE_NUMCODECS_SSE2=""  # [arm64]
     - set DISABLE_NUMCODECS_AVX2=""  # [win]
+    - export CFLAGS="${CFLAGS} -pthread"  # [ppc64le]
     - {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,13 +63,9 @@ about:
   summary: A Python package providing buffer compression and transformation codecs for use in data storage and communication applications.
   description: |
     Numcodecs is a Python package providing buffer compression and transformation codecs for use in data storage and communication applications. These include:
-
     Compression codecs, e.g., Zlib, BZ2, LZMA, ZFPY and Blosc.
-
     Pre-compression filters, e.g., Delta, Quantize, FixedScaleOffset, PackBits, Categorize.
-
     Integrity checks, e.g., CRC32, Adler32.
-
     All codecs implement the same API, allowing codecs to be organized into pipelines in a variety of ways.
   dev_url: https://github.com/zarr-developers/numcodecs
   doc_url: https://numcodecs.readthedocs.io/en/stable/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ build:
     - export DISABLE_NUMCODECS_AVX2=""  # [unix]
     - export DISABLE_NUMCODECS_SSE2=""  # [arm64]
     - set DISABLE_NUMCODECS_AVX2=""  # [win]
-    - export CFLAGS="${CFLAGS} -pthread"  # [aarch64 or ppc64le]
     - {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "numcodecs" %}
-{% set version = "0.9.1" %}
-{% set sha256 = "35adbcc746b95e3ac92e949a161811f5aa2602b9eb1ef241b5ea6f09bb220997" %}
+{% set version = "0.10.2" %}
+{% set sha256 = "22838c6b3fd986bd9c724039b88870057f790e22b20e6e1cbbaa0de142dd59c4" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
**Jira ticket:** [PKG-792](https://anaconda.atlassian.net/browse/PKG-792) (numcodecs-0.10.2)

**The upstream data:**
Github releases:  https://github.com/zarr-developers/numcodecs/releases
[Diff between the latest and previous upstream releases](https://github.com/zarr-developers/numcodecs/compare/0.7.3...0.10.2)
Requirements:
 * setup.py:  https://github.com/zarr-developers/numcodecs/blob/v0.10.2/setup.py

**_Actions:_**

1. Skip `py<37`
2. Add `script`:` export CFLAGS="${CFLAGS} -pthread"  # [aarch64 or ppc64le]`
3. Remove pinnings from `host`
4. Update `run` dependencies
5. Add a `description`

**Notes**
- We update it because **v0.9.1** hasn't python 3.10 support on osx-arm64
- We need to update `zarr` to the latest version after `numcodecs`

**Package's statistics**
<details>

 * Priority C | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 0.10.2
 * Release on PyPi:
    * version: 0.10.2
    * date: 2022-08-01T19:50:35
* [PyPi history](https://pypi.org/project/numcodecs/#history)
 * Popularity: 
    * 3 months downloads: 23201.0
    * All time:  2210113 downloads -  numcodecs  0.10.2  A Python package providing buffer compression and transformation codecs for use in data storage and communication applications.  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/zarr-developers/numcodecs/tree/v0.10.2 exists
8. - [x] https://github.com/zarr-developers/numcodecs is present
9. - [x] Check the pinnings
10. - [x] Additional research
    https://github.com/zarr-developers/numcodecs/issues
    200
11. - [x] `dev_url` is present
    https://github.com/zarr-developers/numcodecs
12. - [x] `doc_url` is present:
13. - [x] Verify that the `build_number` is correct
14. - [x] has `setuptools`
15. - [x] Verify if the package needs `wheel`
16. - [x] `pip` in test
    
17. - [x] Verify the test section
18. - [x] Verify if the package is `architecture specific`
19. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
20.  - [x] license_file: LICENSE is present
21. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |

22. - [x] License family is present
    
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/numcodecs-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/numcodecs-feedstock/tree/0.10.2)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/numcodecs)
* [Diff between upstream and feature branch](https://github.com/conda-forge/numcodecs-feedstock/compare/main...AnacondaRecipes:0.10.2)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/numcodecs-feedstock/compare/master...AnacondaRecipes:0.10.2)
* [The last merged PRs](https://github.com/AnacondaRecipes/numcodecs-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 0.10.2 git@github.com:AnacondaRecipes/numcodecs-feedstock.git
```
