### PR TITLE
Version 0.12.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,10 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - patches/0001-unvendor-c-blosc.patch
 
 build:
   number: 0
@@ -25,7 +26,8 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
+    - patch # [unix]
+    - m2-patch # [win]
   host:
     - python
     - pip
@@ -35,13 +37,19 @@ requirements:
     - wheel
     - toml  # [py<311]
     - py-cpuinfo
+    - blosc 1.21.3
+    - lz4-c 1.9.4
+    - zstd {{ zstd }}
   run:
     - python
     # numcodecs/__init__.py requires msgpack,
     # see https://github.com/zarr-developers/numcodecs/blob/c15e185f6c2d4fa3dc285ac7c975291ef78d1059/numcodecs/__init__.py#L107
     - msgpack-python
     - numpy >=1.7
-
+    # bounds set through run_exports
+    - blosc
+    - lz4-c
+    - zstd
 test:
   requires:
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,6 @@ requirements:
     - py-cpuinfo
   run:
     - python
-    - entrypoints
     # numcodecs/__init__.py requires msgpack,
     # see https://github.com/zarr-developers/numcodecs/blob/c15e185f6c2d4fa3dc285ac7c975291ef78d1059/numcodecs/__init__.py#L107
     - msgpack-python
@@ -46,6 +45,7 @@ requirements:
 test:
   requires:
     - pytest
+    - importlib_metadata
     - pip
   imports:
     - numcodecs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
     - export DISABLE_NUMCODECS_SSE2=""  # [arm64]
     - set DISABLE_NUMCODECS_AVX2=""  # [win]
     - export CFLAGS="${CFLAGS} -pthread"  # [ppc64le]
-    - {{ PYTHON }} -m pip install --no-deps . -vv
+    - {{ PYTHON }} -m pip install --no-deps . -vv --no-build-isolation
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "numcodecs" %}
-{% set version = "0.11.0" %}
-{% set sha256 = "6c058b321de84a1729299b0eae4d652b2e48ea1ca7f9df0da65cb13470e635eb" %}
+{% set version = "0.12.1" %}
+{% set sha256 = "05d91a433733e7eef268d7e80ec226a0232da244289614a8f3826901aec1098e" %}
 
 package:
   name: {{ name|lower }}
@@ -70,7 +70,7 @@ about:
     All codecs implement the same API, allowing codecs to be organized into pipelines in a variety of ways.
   dev_url: https://github.com/zarr-developers/numcodecs
   doc_url: https://numcodecs.readthedocs.io/en/stable/
-  
+
 extra:
   recipe-maintainers:
     - alimanfoo

--- a/recipe/patches/0001-unvendor-c-blosc.patch
+++ b/recipe/patches/0001-unvendor-c-blosc.patch
@@ -1,3 +1,12 @@
+From 3251ccc0d5996edda0d180f1787f0baeb1a016f5 Mon Sep 17 00:00:00 2001
+From: Charles Bousseau <cbousseau@anaconda.com>
+Date: Wed, 7 Feb 2024 16:59:16 -0500
+Subject: [PATCH] unvendor cblosc
+
+---
+ setup.py | 85 ++++++++++++--------------------------------------------
+ 1 file changed, 18 insertions(+), 67 deletions(-)
+
 diff --git a/setup.py b/setup.py
 index f07cf8d..178179a 100644
 --- a/setup.py
@@ -137,3 +146,6 @@ index f07cf8d..178179a 100644
                    ),
      ]
  
+-- 
+2.39.3 (Apple Git-145)
+

--- a/recipe/patches/0001-unvendor-c-blosc.patch
+++ b/recipe/patches/0001-unvendor-c-blosc.patch
@@ -1,0 +1,139 @@
+diff --git a/setup.py b/setup.py
+index f07cf8d..178179a 100644
+--- a/setup.py
++++ b/setup.py
+@@ -51,61 +51,21 @@ def blosc_extension():
+ 
+     extra_compile_args = base_compile_args.copy()
+     define_macros = []
+-
+-    # setup blosc sources
+-    blosc_sources = [f for f in glob('c-blosc/blosc/*.c')
+-                     if 'avx2' not in f and 'sse2' not in f]
+-    include_dirs = [os.path.join('c-blosc', 'blosc')]
+-
+-    # add internal complibs
+-    blosc_sources += glob('c-blosc/internal-complibs/lz4*/*.c')
+-    blosc_sources += glob('c-blosc/internal-complibs/snappy*/*.cc')
+-    blosc_sources += glob('c-blosc/internal-complibs/zlib*/*.c')
+-    blosc_sources += glob('c-blosc/internal-complibs/zstd*/common/*.c')
+-    blosc_sources += glob('c-blosc/internal-complibs/zstd*/compress/*.c')
+-    blosc_sources += glob('c-blosc/internal-complibs/zstd*/decompress/*.c')
+-    blosc_sources += glob('c-blosc/internal-complibs/zstd*/dictBuilder/*.c')
+-    include_dirs += [d for d in glob('c-blosc/internal-complibs/*')
+-                     if os.path.isdir(d)]
+-    include_dirs += [d for d in glob('c-blosc/internal-complibs/*/*')
+-                     if os.path.isdir(d)]
+-    include_dirs += [d for d in glob('c-blosc/internal-complibs/*/*/*')
+-                     if os.path.isdir(d)]
+-    define_macros += [('HAVE_LZ4', 1),
+-                      # ('HAVE_SNAPPY', 1),
+-                      ('HAVE_ZLIB', 1),
+-                      ('HAVE_ZSTD', 1)]
+-    # define_macros += [('CYTHON_TRACE', '1')]
+-
+-    # SSE2
+-    if have_sse2 and not disable_sse2:
+-        info('compiling Blosc extension with SSE2 support')
+-        extra_compile_args.append('-DSHUFFLE_SSE2_ENABLED')
+-        blosc_sources += [f for f in glob('c-blosc/blosc/*.c') if 'sse2' in f]
+-        if os.name == 'nt':
+-            define_macros += [('__SSE2__', 1)]
+-    else:
+-        info('compiling Blosc extension without SSE2 support')
+-
+-    # AVX2
+-    if have_avx2 and not disable_avx2:
+-        info('compiling Blosc extension with AVX2 support')
+-        extra_compile_args.append('-DSHUFFLE_AVX2_ENABLED')
+-        blosc_sources += [f for f in glob('c-blosc/blosc/*.c') if 'avx2' in f]
+-        if os.name == 'nt':
+-            define_macros += [('__AVX2__', 1)]
+-    else:
+-        info('compiling Blosc extension without AVX2 support')
++    include_dirs = [os.path.join(sys.prefix, 'include')]
++    library_dirs = [os.path.join(sys.prefix, 'lib')]
++    libraries = ["blosc"]
+ 
+     sources = ['numcodecs/blosc.pyx']
+ 
+     # define extension module
+     extensions = [
+         Extension('numcodecs.blosc',
+-                  sources=sources + blosc_sources,
++                  sources=sources,
+                   include_dirs=include_dirs,
+                   define_macros=define_macros,
+                   extra_compile_args=extra_compile_args,
++                  library_dirs=library_dirs,
++                  libraries=libraries
+                   ),
+     ]
+ 
+@@ -115,31 +75,23 @@ def blosc_extension():
+ def zstd_extension():
+     info('setting up Zstandard extension')
+ 
+-    zstd_sources = []
+     extra_compile_args = base_compile_args.copy()
+-    include_dirs = []
+     define_macros = []
+-
+-    # setup sources - use zstd bundled in blosc
+-    zstd_sources += glob('c-blosc/internal-complibs/zstd*/common/*.c')
+-    zstd_sources += glob('c-blosc/internal-complibs/zstd*/compress/*.c')
+-    zstd_sources += glob('c-blosc/internal-complibs/zstd*/decompress/*.c')
+-    zstd_sources += glob('c-blosc/internal-complibs/zstd*/dictBuilder/*.c')
+-    include_dirs += [d for d in glob('c-blosc/internal-complibs/zstd*')
+-                     if os.path.isdir(d)]
+-    include_dirs += [d for d in glob('c-blosc/internal-complibs/zstd*/*')
+-                     if os.path.isdir(d)]
+-    # define_macros += [('CYTHON_TRACE', '1')]
++    include_dirs = [os.path.join(sys.prefix, 'include')]
++    library_dirs = [os.path.join(sys.prefix, 'lib')]
++    libraries = ["zstd"]
+ 
+     sources = ['numcodecs/zstd.pyx']
+ 
+     # define extension module
+     extensions = [
+         Extension('numcodecs.zstd',
+-                  sources=sources + zstd_sources,
++                  sources=sources,
+                   include_dirs=include_dirs,
+                   define_macros=define_macros,
+                   extra_compile_args=extra_compile_args,
++                  library_dirs=library_dirs,
++                  libraries=libraries
+                   ),
+     ]
+ 
+@@ -151,22 +103,21 @@ def lz4_extension():
+ 
+     extra_compile_args = base_compile_args.copy()
+     define_macros = []
+-
+-    # setup sources - use LZ4 bundled in blosc
+-    lz4_sources = glob('c-blosc/internal-complibs/lz4*/*.c')
+-    include_dirs = [d for d in glob('c-blosc/internal-complibs/lz4*') if os.path.isdir(d)]
+-    include_dirs += ['numcodecs']
+-    # define_macros += [('CYTHON_TRACE', '1')]
++    include_dirs = [os.path.join(sys.prefix, 'include')]
++    library_dirs = [os.path.join(sys.prefix, 'lib')]
++    libraries = ["lz4"]
+ 
+     sources = ['numcodecs/lz4.pyx']
+ 
+     # define extension module
+     extensions = [
+         Extension('numcodecs.lz4',
+-                  sources=sources + lz4_sources,
++                  sources=sources,
+                   include_dirs=include_dirs,
+                   define_macros=define_macros,
+                   extra_compile_args=extra_compile_args,
++                  library_dirs=library_dirs,
++                  libraries=libraries
+                   ),
+     ]
+ 

--- a/recipe/patches/0001-unvendor-c-blosc.patch
+++ b/recipe/patches/0001-unvendor-c-blosc.patch
@@ -129,7 +129,7 @@ index f07cf8d..178179a 100644
 -    # define_macros += [('CYTHON_TRACE', '1')]
 +    include_dirs = [os.path.join(sys.prefix, 'include')]
 +    library_dirs = [os.path.join(sys.prefix, 'lib')]
-+    libraries = ["lz4"]
++    libraries = ['liblz4' if os.name == 'nt' else 'lz4']
  
      sources = ['numcodecs/lz4.pyx']
  


### PR DESCRIPTION
numcodecs 0.12.1

**Destination channel:** defaults

### Links

- [PKG-3807](https://anaconda.atlassian.net/browse/PKG-3807)
- [Upstream repository](https://github.com/zarr-developers/numcodecs/tree/v0.12.1)
- [Upstream changelog/diff](https://numcodecs.readthedocs.io/en/stable/release.html#release-0-12-1)

### Explanation of changes:

- Bump version to `0.12.1`
- Unvendor `cblosc`
- Linter fixes
- Dependency updates

[PKG-3807]: https://anaconda.atlassian.net/browse/PKG-3807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ