### PR TITLE
numcodecs 0.14.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-aggregate_branch: 3.12
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "numcodecs" %}
-{% set version = "0.12.1" %}
-{% set sha256 = "05d91a433733e7eef268d7e80ec226a0232da244289614a8f3826901aec1098e" %}
+{% set version = "0.14.1" %}
 
 package:
   name: {{ name|lower }}
@@ -8,19 +7,18 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 00a364924fd2d600bcce6e2ced96b47c40eb5f9d84bf4b0207aa208d9ce6cd1c
   patches:
     - patches/0001-unvendor-c-blosc.patch
 
 build:
   number: 0
   # numcodecs is not currently supported on s390x
-  skip: True  # [py<38 or s390x]
+  skip: True  # [py<311 or s390x]
   script:
     - export DISABLE_NUMCODECS_AVX2=""  # [unix]
-    - export DISABLE_NUMCODECS_SSE2=""  # [arm64]
+    - export DISABLE_NUMCODECS_SSE2=""  # [osx and arm64]
     - set DISABLE_NUMCODECS_AVX2=""  # [win]
-    - export CFLAGS="${CFLAGS} -pthread"  # [ppc64le]
     - {{ PYTHON }} -m pip install --no-deps . -vv --no-build-isolation
 
 requirements:
@@ -32,24 +30,26 @@ requirements:
     - python
     - pip
     - cython
-    - setuptools
-    - setuptools_scm
+    - setuptools >=64
     - wheel
     - toml  # [py<311]
     - py-cpuinfo
     - blosc 1.21.3
     - lz4-c 1.9.4
     - zstd {{ zstd }}
+    - setuptools-scm >=6.2
+    - numpy 2
   run:
     - python
     # numcodecs/__init__.py requires msgpack,
     # see https://github.com/zarr-developers/numcodecs/blob/c15e185f6c2d4fa3dc285ac7c975291ef78d1059/numcodecs/__init__.py#L107
     - msgpack-python
-    - numpy >=1.7
+    - numpy >=1.24,<3
     # bounds set through run_exports
     - blosc
     - lz4-c
     - zstd
+
 test:
   requires:
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,6 +62,8 @@ test:
     - numcodecs.zstd
   commands:
     - pip check
+    # check that pip gets the correct version
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - pytest -v --pyargs numcodecs
 
 about:

--- a/recipe/patches/0001-unvendor-c-blosc.patch
+++ b/recipe/patches/0001-unvendor-c-blosc.patch
@@ -4,21 +4,16 @@ Date: Wed, 7 Feb 2024 16:59:16 -0500
 Subject: [PATCH] unvendor cblosc
 
 ---
- setup.py | 85 ++++++++++++--------------------------------------------
- 1 file changed, 18 insertions(+), 67 deletions(-)
-
 diff --git a/setup.py b/setup.py
-index f07cf8d..178179a 100644
+index b6db079..80a6da2 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -51,61 +51,21 @@ def blosc_extension():
- 
+@@ -55,50 +55,9 @@ def blosc_extension():
      extra_compile_args = base_compile_args.copy()
      define_macros = []
--
+ 
 -    # setup blosc sources
--    blosc_sources = [f for f in glob('c-blosc/blosc/*.c')
--                     if 'avx2' not in f and 'sse2' not in f]
+-    blosc_sources = [f for f in glob('c-blosc/blosc/*.c') if 'avx2' not in f and 'sse2' not in f]
 -    include_dirs = [os.path.join('c-blosc', 'blosc')]
 -
 -    # add internal complibs
@@ -29,16 +24,17 @@ index f07cf8d..178179a 100644
 -    blosc_sources += glob('c-blosc/internal-complibs/zstd*/compress/*.c')
 -    blosc_sources += glob('c-blosc/internal-complibs/zstd*/decompress/*.c')
 -    blosc_sources += glob('c-blosc/internal-complibs/zstd*/dictBuilder/*.c')
--    include_dirs += [d for d in glob('c-blosc/internal-complibs/*')
--                     if os.path.isdir(d)]
--    include_dirs += [d for d in glob('c-blosc/internal-complibs/*/*')
--                     if os.path.isdir(d)]
--    include_dirs += [d for d in glob('c-blosc/internal-complibs/*/*/*')
--                     if os.path.isdir(d)]
--    define_macros += [('HAVE_LZ4', 1),
--                      # ('HAVE_SNAPPY', 1),
--                      ('HAVE_ZLIB', 1),
--                      ('HAVE_ZSTD', 1)]
+-    include_dirs += [d for d in glob('c-blosc/internal-complibs/*') if os.path.isdir(d)]
+-    include_dirs += [d for d in glob('c-blosc/internal-complibs/*/*') if os.path.isdir(d)]
+-    include_dirs += [d for d in glob('c-blosc/internal-complibs/*/*/*') if os.path.isdir(d)]
+-    # remove minizip because Python.h 3.8 tries to include crypt.h
+-    include_dirs = [d for d in include_dirs if 'minizip' not in d]
+-    define_macros += [
+-        ('HAVE_LZ4', 1),
+-        # ('HAVE_SNAPPY', 1),
+-        ('HAVE_ZLIB', 1),
+-        ('HAVE_ZSTD', 1),
+-    ]
 -    # define_macros += [('CYTHON_TRACE', '1')]
 -
 -    # SSE2
@@ -64,22 +60,24 @@ index f07cf8d..178179a 100644
 +    library_dirs = [os.path.join(sys.prefix, 'lib')]
 +    libraries = ["blosc"]
  
-     sources = ['numcodecs/blosc.pyx']
- 
-     # define extension module
+     # include assembly files
+     if cpuinfo.platform.machine() == 'x86_64':
+@@ -114,11 +73,13 @@ def blosc_extension():
      extensions = [
-         Extension('numcodecs.blosc',
--                  sources=sources + blosc_sources,
-+                  sources=sources,
-                   include_dirs=include_dirs,
-                   define_macros=define_macros,
-                   extra_compile_args=extra_compile_args,
-+                  library_dirs=library_dirs,
-+                  libraries=libraries
-                   ),
+         Extension(
+             'numcodecs.blosc',
+-            sources=sources + blosc_sources,
++            sources=sources,
+             include_dirs=include_dirs,
+             define_macros=define_macros,
+             extra_compile_args=extra_compile_args,
+             extra_objects=extra_objects,
++            library_dirs=library_dirs,
++            libraries=libraries
+         ),
      ]
  
-@@ -115,31 +75,23 @@ def blosc_extension():
+@@ -128,19 +89,12 @@ def blosc_extension():
  def zstd_extension():
      info('setting up Zstandard extension')
  
@@ -87,16 +85,14 @@ index f07cf8d..178179a 100644
      extra_compile_args = base_compile_args.copy()
 -    include_dirs = []
      define_macros = []
--
+ 
 -    # setup sources - use zstd bundled in blosc
 -    zstd_sources += glob('c-blosc/internal-complibs/zstd*/common/*.c')
 -    zstd_sources += glob('c-blosc/internal-complibs/zstd*/compress/*.c')
 -    zstd_sources += glob('c-blosc/internal-complibs/zstd*/decompress/*.c')
 -    zstd_sources += glob('c-blosc/internal-complibs/zstd*/dictBuilder/*.c')
--    include_dirs += [d for d in glob('c-blosc/internal-complibs/zstd*')
--                     if os.path.isdir(d)]
--    include_dirs += [d for d in glob('c-blosc/internal-complibs/zstd*/*')
--                     if os.path.isdir(d)]
+-    include_dirs += [d for d in glob('c-blosc/internal-complibs/zstd*') if os.path.isdir(d)]
+-    include_dirs += [d for d in glob('c-blosc/internal-complibs/zstd*/*') if os.path.isdir(d)]
 -    # define_macros += [('CYTHON_TRACE', '1')]
 +    include_dirs = [os.path.join(sys.prefix, 'include')]
 +    library_dirs = [os.path.join(sys.prefix, 'lib')]
@@ -104,48 +100,16 @@ index f07cf8d..178179a 100644
  
      sources = ['numcodecs/zstd.pyx']
  
-     # define extension module
+@@ -156,11 +110,127 @@ def zstd_extension():
      extensions = [
-         Extension('numcodecs.zstd',
--                  sources=sources + zstd_sources,
-+                  sources=sources,
-                   include_dirs=include_dirs,
-                   define_macros=define_macros,
-                   extra_compile_args=extra_compile_args,
-+                  library_dirs=library_dirs,
-+                  libraries=libraries
-                   ),
-     ]
- 
-@@ -151,22 +103,21 @@ def lz4_extension():
- 
-     extra_compile_args = base_compile_args.copy()
-     define_macros = []
--
--    # setup sources - use LZ4 bundled in blosc
--    lz4_sources = glob('c-blosc/internal-complibs/lz4*/*.c')
--    include_dirs = [d for d in glob('c-blosc/internal-complibs/lz4*') if os.path.isdir(d)]
--    include_dirs += ['numcodecs']
--    # define_macros += [('CYTHON_TRACE', '1')]
-+    include_dirs = [os.path.join(sys.prefix, 'include')]
-+    library_dirs = [os.path.join(sys.prefix, 'lib')]
-+    libraries = ['liblz4' if os.name == 'nt' else 'lz4']
- 
-     sources = ['numcodecs/lz4.pyx']
- 
-     # define extension module
-     extensions = [
-         Extension('numcodecs.lz4',
--                  sources=sources + lz4_sources,
-+                  sources=sources,
-                   include_dirs=include_dirs,
-                   define_macros=define_macros,
-                   extra_compile_args=extra_compile_args,
-+                  library_dirs=library_dirs,
-+                  libraries=libraries
-                   ),
-     ]
- 
+         Extension(
+             'numcodecs.zstd',
+-            sources=sources + zstd_sources,
++            sources=sources,
+             include_dirs=include_dirs,
+             define_macros=define_macros,
+             extra_compile_args=extra_compile_args,
+             extra_objects=extra_objects,
 -- 
 2.39.3 (Apple Git-145)
 

--- a/recipe/patches/0001-unvendor-c-blosc.patch
+++ b/recipe/patches/0001-unvendor-c-blosc.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] unvendor cblosc
 
 ---
 diff --git a/setup.py b/setup.py
-index b6db079..80a6da2 100644
+index b6db079..868fce1
 --- a/setup.py
 +++ b/setup.py
-@@ -55,50 +55,9 @@ def blosc_extension():
+@@ -55,70 +55,25 @@ def blosc_extension():
      extra_compile_args = base_compile_args.copy()
      define_macros = []
  
@@ -56,13 +56,23 @@ index b6db079..80a6da2 100644
 -            define_macros += [('__AVX2__', 1)]
 -    else:
 -        info('compiling Blosc extension without AVX2 support')
+-
+-    # include assembly files
+-    if cpuinfo.platform.machine() == 'x86_64':
+-        extra_objects = [
+-            S[:-1] + 'o' for S in glob("c-blosc/internal-complibs/zstd*/decompress/*amd64.S")
+-        ]
+-    else:
+-        extra_objects = []
 +    include_dirs = [os.path.join(sys.prefix, 'include')]
 +    library_dirs = [os.path.join(sys.prefix, 'lib')]
 +    libraries = ["blosc"]
  
-     # include assembly files
-     if cpuinfo.platform.machine() == 'x86_64':
-@@ -114,11 +73,13 @@ def blosc_extension():
+     sources = ['numcodecs/blosc.pyx']
+ 
++    extra_objects = []
++
+     # define extension module
      extensions = [
          Extension(
              'numcodecs.blosc',
@@ -77,7 +87,7 @@ index b6db079..80a6da2 100644
          ),
      ]
  
-@@ -128,19 +89,12 @@ def blosc_extension():
+@@ -128,39 +83,28 @@ def blosc_extension():
  def zstd_extension():
      info('setting up Zstandard extension')
  
@@ -100,7 +110,16 @@ index b6db079..80a6da2 100644
  
      sources = ['numcodecs/zstd.pyx']
  
-@@ -156,11 +110,127 @@ def zstd_extension():
+-    # include assembly files
+-    if cpuinfo.platform.machine() == 'x86_64':
+-        extra_objects = [
+-            S[:-1] + 'o' for S in glob("c-blosc/internal-complibs/zstd*/decompress/*amd64.S")
+-        ]
+-    else:
+-        extra_objects = []
++    extra_objects = []
+ 
+     # define extension module
      extensions = [
          Extension(
              'numcodecs.zstd',
@@ -110,6 +129,41 @@ index b6db079..80a6da2 100644
              define_macros=define_macros,
              extra_compile_args=extra_compile_args,
              extra_objects=extra_objects,
++            library_dirs=library_dirs,
++            libraries=libraries
+         ),
+     ]
+ 
+@@ -173,11 +117,9 @@ def lz4_extension():
+     extra_compile_args = base_compile_args.copy()
+     define_macros = []
+ 
+-    # setup sources - use LZ4 bundled in blosc
+-    lz4_sources = glob('c-blosc/internal-complibs/lz4*/*.c')
+-    include_dirs = [d for d in glob('c-blosc/internal-complibs/lz4*') if os.path.isdir(d)]
+-    include_dirs += ['numcodecs']
+-    # define_macros += [('CYTHON_TRACE', '1')]
++    include_dirs = [os.path.join(sys.prefix, 'include')]
++    library_dirs = [os.path.join(sys.prefix, 'lib')]
++    libraries = ['liblz4' if os.name == 'nt' else 'lz4']
+ 
+     sources = ['numcodecs/lz4.pyx']
+ 
+@@ -185,10 +127,12 @@ def lz4_extension():
+     extensions = [
+         Extension(
+             'numcodecs.lz4',
+-            sources=sources + lz4_sources,
++            sources=sources,
+             include_dirs=include_dirs,
+             define_macros=define_macros,
+             extra_compile_args=extra_compile_args,
++            library_dirs=library_dirs,
++            libraries=libraries
+         ),
+     ]
+ 
+
 -- 
-2.39.3 (Apple Git-145)
+2.47.0
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6598](https://anaconda.atlassian.net/browse/PKG-6598)
- [Upstream repo](https://github.com/zarr-developers/numcodecs/tree/v0.14.1)
- release-diff: https://github.com/zarr-developers/numcodecs/compare/v0.12.1...v0.14.1
- requirements-tagged:
  - https://github.com/zarr-developers/numcodecs/blob/v0.14.1/pyproject.toml
  - https://github.com/zarr-developers/numcodecs/blob/v0.14.1/setup.py


### Explanation of changes:

- Skip `py<311`
- Use `numpy 2` in `host` and `numpy >=1.24,<3` in `run`
- Refresh a patch

### Notes:

- `numcodecs` is an optional test dependency of `imagecodecs` https://github.com/AnacondaRecipes/imagecodecs-feedstock/pull/17

[PKG-6598]: https://anaconda.atlassian.net/browse/PKG-6598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ